### PR TITLE
Validate Load() and Dump() opertions

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -21,9 +21,6 @@ func TestClientWithValidCredentials(t *testing.T) {
 	if client.LicenseSearch == nil {
 		t.Fatal("improperly initialized client, missing LicenseSearch")
 	}
-	if client.AssetLibrary == nil {
-		t.Fatal("improperly initialized client, missing AssetLibrary")
-	}
 }
 
 func TestClientWithInvalidCredentials(t *testing.T) {


### PR DESCRIPTION
The API for the `Load()` and `Dump()` functions has changed to return an error in case of a failure, e.g. when an invalid input was provided.